### PR TITLE
update to work with tresorit_installer.run version 3.5.938.2150

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@ stdenv.mkDerivation rec {
 
   src = fetchurl {
     url = https://installerstorage.blob.core.windows.net/public/install/tresorit_installer.run;
-    sha256 = "18507prr228q0csfqri4k9yiyzmrinzx5rxc67acvf710qzsqn6r";
+    sha256 = "0m83zb59v1fkyrc9lkyggiifcrh5mfxg579bk8512szypn7m83mp";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];
@@ -24,7 +24,7 @@ stdenv.mkDerivation rec {
   dontMake = true;
 
   unpackPhase  = ''
-    tail -n+94 $src | tar xz -C $TMP
+    tail -c+8616 $src | tar xz -C $TMP
   '';
 
   installPhase = ''


### PR DESCRIPTION
Updated sha256 and byte offset for the gzip archive contained in the binary so that it works with tresorit_installer.run version 3.5.938.2150. Tested on nixos 21.05/x86-64.