### PR TITLE
feat: tresorit 3.5.1241.4340

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ openat(AT_FDCWD, "/nix/store/0qrdl9f7qpk4vfk3j854vri941jccw1z-tresorit-3.5.698.8
 # Bypass with "impure" method
 
 ``` shell
-nix run -f release.nix -c install-tresorit-impure
+NIXPKGS_ALLOW_UNFREE=1 nix shell -f release.nix -c install-tresorit-impure
 ```
 
-This install tresorit in your $HOME/.local/tresorit (as does the
+This install tresorit in your $HOME/.local/share/tresorit (as does the
 tresorit installation script)
 
 or

--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@ with import <nixpkgs> {};
 
 stdenv.mkDerivation rec {
 
-  version = "3.5.1241.4340";
+  version = "3.5.1244.4360";
   name = "tresorit-${version}";
 
   src = fetchurl {
     url = https://installerstorage.blob.core.windows.net/public/install/tresorit_installer.run;
-    sha256 = "763130c3da9720cc35e8051083c41d774930b860b56ade1f1b77c5b06c733b65";
+    sha256 = "865bf2e54791546e9637823671ca5475091b6f8a2599c668040d3feed092b6ee";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];

--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@ with import <nixpkgs> {};
 
 stdenv.mkDerivation rec {
 
-  version = "3.5.1018.2760";
+  version = "3.5.1241.4340";
   name = "tresorit-${version}";
 
   src = fetchurl {
     url = https://installerstorage.blob.core.windows.net/public/install/tresorit_installer.run;
-    sha256 = "12sbjdwf334r6ga3ssdirkvivkflcnymqhc7k1389rd9i62glsn2";
+    sha256 = "763130c3da9720cc35e8051083c41d774930b860b56ade1f1b77c5b06c733b65";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];

--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,13 @@ let
   run-tresorit-install-script = writeShellScriptBin "install-tresorit-impure" ''
     mkdir -p $HOME/.local/share/tresorit
     cp -rf ${pure}/bin/* $HOME/.local/share/tresorit/
+    chmod +w $HOME/.local/share/tresorit/tresorit.desktop
+    cat >> $HOME/.local/share/tresorit/tresorit.desktop << EOF
+    Exec=$HOME/.local/share/tresorit/tresorit %u
+    MimeType=x-scheme-handler/tresorit
+    Icon=$HOME/.local/share/tresorit/tresorit.png
+    EOF
+    ln -s $HOME/.local/share/tresorit/tresorit.desktop $HOME/.local/share/applications/tresorit.desktop
   '';
   run-tresorit-script = writeShellScriptBin "tresorit-impure" ''
     BIN=$HOME/.local/share/tresorit/tresorit

--- a/release.nix
+++ b/release.nix
@@ -4,11 +4,11 @@ let
   installUsage = "You must first run install-tresorit-impure before using this command.";
   pure = import ./default.nix {};
   run-tresorit-install-script = writeShellScriptBin "install-tresorit-impure" ''
-    mkdir -p $HOME/.local/tresorit
-    cp -rf ${pure}/bin/* $HOME/.local/tresorit/
+    mkdir -p $HOME/.local/share/tresorit
+    cp -rf ${pure}/bin/* $HOME/.local/share/tresorit/
   '';
   run-tresorit-script = writeShellScriptBin "tresorit-impure" ''
-    BIN=$HOME/.local/tresorit/tresorit
+    BIN=$HOME/.local/share/tresorit/tresorit
     if [ -f $BIN ]; then
       $BIN "$@"
     else
@@ -16,7 +16,7 @@ let
     fi
   '';
   run-tresorit-cli-script = writeShellScriptBin "tresorit-cli-impure" ''
-    BIN=$HOME/.local/tresorit/tresorit-cli
+    BIN=$HOME/.local/share/tresorit/tresorit-cli
     if [ -f $BIN ]; then
       $BIN "$@"
     else


### PR DESCRIPTION
This PR updates Tresorit to `3.5.1241.4340` (addresses https://github.com/apeyroux/tresorit.nix/issues/3) and does a bit of house-keeping:

- Updates the `nix` command to work with newer Nix versions.
- Documents the env var to temporarily allow unfree software installation.
- Installs Tresorit into `$HOME/.local/share` instead of `$HOME/.local` as does the current Tresorit installer.
- Symlinks the `tresorit.desktop` file to `$HOME/.local/share/applications/tresorit.desktop` so it can be picked up by desktop environments such as Gnome.