### PR TITLE
feat: bump to `3.5.1266.4580`

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@ with import <nixpkgs> {};
 
 stdenv.mkDerivation rec {
 
-  version = "3.5.1266.4580";
+  version = "3.5.1274.4640";
   name = "tresorit-${version}";
 
   src = fetchurl {
     url = https://installerstorage.blob.core.windows.net/public/install/tresorit_installer.run;
-    sha256 = "e833b741564ae567e139314b5cc8509c281aa78c17f593acba8d37192ad378a0";
+    sha256 = "86db6c8cee4a4456d02a21941863478986caeb53fbf38394f2826635851dd9fd";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];

--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@ with import <nixpkgs> {};
 
 stdenv.mkDerivation rec {
 
-  version = "3.5.1274.4640";
+  version = "3.5.1281.4700";
   name = "tresorit-${version}";
 
   src = fetchurl {
     url = https://installerstorage.blob.core.windows.net/public/install/tresorit_installer.run;
-    sha256 = "86db6c8cee4a4456d02a21941863478986caeb53fbf38394f2826635851dd9fd";
+    sha256 = "e8f1a9f379854894a5066c9c2b22184be914f6566955667c15971cba4763c943";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];

--- a/default.nix
+++ b/default.nix
@@ -4,12 +4,12 @@ with import <nixpkgs> {};
 
 stdenv.mkDerivation rec {
 
-  version = "3.5.1244.4360";
+  version = "3.5.1266.4580";
   name = "tresorit-${version}";
 
   src = fetchurl {
     url = https://installerstorage.blob.core.windows.net/public/install/tresorit_installer.run;
-    sha256 = "865bf2e54791546e9637823671ca5475091b6f8a2599c668040d3feed092b6ee";
+    sha256 = "e833b741564ae567e139314b5cc8509c281aa78c17f593acba8d37192ad378a0";
   };
 
   nativeBuildInputs = [ autoPatchelfHook ];


### PR DESCRIPTION
Bumping to the latest Tresorit version.

Thank you very much for making this repo, by the way!